### PR TITLE
sync original when populating collection

### DIFF
--- a/src/WeclappQueryBuilder.php
+++ b/src/WeclappQueryBuilder.php
@@ -373,7 +373,7 @@ class WeclappQueryBuilder extends Builder
 
         foreach ($items['result'] as $item) {
             $results[] = $this->model->newInstance([], true)
-                ->setRawAttributes($item);
+                ->setRawAttributes($item, true);
         }
         return $this->getModel()->newCollection($results);
     }


### PR DESCRIPTION
at the moment all the models in the collection are dirty.
```php
>>> use Geccomedia\Weclapp\Models\Article;
>>> Article::first()->isDirty();
true
```
so syncing to original should fix this