### PR TITLE
fix newModelInstance(), since we have no database connection

### DIFF
--- a/src/WeclappQueryBuilder.php
+++ b/src/WeclappQueryBuilder.php
@@ -538,4 +538,16 @@ class WeclappQueryBuilder extends Builder
 
         return $item['version'] != $this->model->version;
     }
+
+
+    /**
+     * Create a new instance of the model being queried.
+     *
+     * @param  array  $attributes
+     * @return WeclappModel|static
+     */
+    public function newModelInstance($attributes = [])
+    {
+        return $this->model->newInstance($attributes);
+    }
 }


### PR DESCRIPTION
Hey,

methods like create() uses newModelInstance()
this fails because the WeclappBaseQueryBuilder has no connection
Error is:
PHP Error:  Call to a member function getName() on null in vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php on line 1102
