### PR TITLE
laravel 10 compatibility: use $casts instead of $dates, fix Builder::whereSub() signature

### DIFF
--- a/src/Models/SalesInvoice.php
+++ b/src/Models/SalesInvoice.php
@@ -16,15 +16,15 @@ class SalesInvoice extends Model
      *
      * @var array
      */
-    protected $dates = [
-        'createdDate',
-        'deliveryDate',
-        'dueDate',
-        'invoiceDate',
-        'lastModifiedDate',
-        'pricingDate',
-        'servicePeriodFrom',
-        'servicePeriodTo',
-        'shippingDate'
+    protected $casts = [
+        'createdDate' => 'datetime',
+        'deliveryDate' => 'datetime',
+        'dueDate' => 'datetime',
+        'invoiceDate' => 'datetime',
+        'lastModifiedDate' => 'datetime',
+        'pricingDate' => 'datetime',
+        'servicePeriodFrom' => 'datetime',
+        'servicePeriodTo' => 'datetime',
+        'shippingDate' => 'datetime'
     ];
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -57,7 +57,7 @@ class Builder extends BaseBuilder
         throw new NotSupportedException('raw wheres are not supported by weclapp');
     }
 
-    protected function whereSub($column, $operator, \Closure $callback, $boolean)
+    protected function whereSub($column, $operator, $callback, $boolean)
     {
         throw new NotSupportedException('whereSub wheres are not supported by weclapp');
     }


### PR DESCRIPTION
i tested it with orechestra/testbench ^6.0, ^7.0 and ^8.0 on php 8.2