### PR TITLE
Fix Laravel 12 compatibility - implement prepareBindings(

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -430,7 +430,7 @@ class Connection implements ConnectionInterface
 
     public function prepareBindings(array $bindings)
     {
-        throw new NotSupportedException('prepareBindings not supported by weclapp');
+        return $bindings;
     }
 
     public function scalar($query, $bindings = [], $useReadPdo = true)

--- a/src/Models/Opportunity.php
+++ b/src/Models/Opportunity.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Geccomedia\Weclapp\Models;
+
+use Geccomedia\Weclapp\Model;
+
+class Opportunity extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'opportunity';
+}


### PR DESCRIPTION
# Fix Laravel 12 compatibility - implement prepareBindings()

## Problem

Laravel 12 calls `prepareBindings()` internally, current implementation throws `NotSupportedException`, breaking all queries.

## Fix

Return bindings unchanged instead of throwing exception:

```php
public function prepareBindings(array $bindings)
{
    return $bindings;
}
```

Package uses `json_encode()` for serialization (not PDO), so no preparation needed.

**Tested:** Laravel 12.44.0 + PHP 8.5
